### PR TITLE
Fix build errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,14 +114,14 @@
 			<groupId>net.tirasa.connid</groupId>
 			<artifactId>connector-framework</artifactId>
 			<!-- version>1.4.2.19</version-->
-			<version>1.4.3.0-SNAPSHOT</version>
+			<version>1.4.3.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>net.tirasa.connid</groupId>
 			<artifactId>connector-framework-internal</artifactId>
 			<!-- version>1.4.2.19</version-->
-			<version>1.4.3.0-SNAPSHOT</version>
+			<version>1.4.3.0</version>
 			<scope>compile</scope>
 		</dependency>
 		

--- a/src/main/java/com/evolveum/polygon/connector/box/rest/BoxConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/box/rest/BoxConnector.java
@@ -194,8 +194,6 @@ public class BoxConnector implements TestOp, SchemaOp, Connector, DeleteOp, Sear
 			if (objectClass.is(ObjectClass.ACCOUNT_NAME)) {
 				UserHandler user = new UserHandler(configuration);
 				user.executeQuery(objectClass, query, handler, options);
-			} else if (!configuration.isEnableFilteredResultsHandler()) {
-				throw new ConnectorException("Unsupported filter: StartWithFilter for " + objectClass);
 			}
 
 			// EqualsFilter
@@ -211,7 +209,7 @@ public class BoxConnector implements TestOp, SchemaOp, Connector, DeleteOp, Sear
 				folder.executeQuery(objectClass, query, handler, options);
 			}
 
-		} else if (configuration.isEnableFilteredResultsHandler() && query instanceof Filter) {
+		} else if (query instanceof Filter) {
 			if (objectClass.is(ObjectClass.ACCOUNT_NAME)) {
 				UserHandler user = new UserHandler(configuration);
 				user.executeQuery(objectClass, query, handler, options);
@@ -232,8 +230,6 @@ public class BoxConnector implements TestOp, SchemaOp, Connector, DeleteOp, Sear
 		} else if (query == null && objectClass.is(FOLDER_NAME)) {
 			FoldersHandler folder = new FoldersHandler(configuration);
 			folder.executeQuery(objectClass, query, handler, options);
-		} else {
-			throw new ConnectorException("Unsupported query filter: " + query);
 		}
 	}
 

--- a/src/main/java/com/evolveum/polygon/connector/box/rest/BoxConnectorConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/box/rest/BoxConnectorConfiguration.java
@@ -20,7 +20,6 @@ import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.ConfigurationException;
 import org.identityconnectors.framework.spi.AbstractConfiguration;
-import org.identityconnectors.framework.spi.ConfigurationForResultsHandler;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
 import org.identityconnectors.framework.spi.StatefulConfiguration;
 
@@ -29,7 +28,7 @@ import org.identityconnectors.framework.spi.StatefulConfiguration;
  *
  */
 public class BoxConnectorConfiguration extends AbstractConfiguration
-		implements StatefulConfiguration, ConfigurationForResultsHandler {
+		implements StatefulConfiguration {
 
 	private String clientId;
 	private String URI;
@@ -122,67 +121,4 @@ public class BoxConnectorConfiguration extends AbstractConfiguration
 	@Override
 	public void release() {
 	}
-
-	@Override
-	public boolean isEnableAttributesToGetSearchResultsHandler() {
-		return enableAttributesToGetSearchResultsHandler;
-	}
-
-	@Override
-	public void setEnableAttributesToGetSearchResultsHandler(boolean enableAttributesToGetSearchResultsHandler) {
-		LOGGER.info("I AM SETTING AttributesToGetSearchResultsHandler : {0}",
-				String.valueOf(enableAttributesToGetSearchResultsHandler));
-		this.enableAttributesToGetSearchResultsHandler = enableAttributesToGetSearchResultsHandler;
-
-	}
-
-	@Override
-	public boolean isEnableCaseInsensitiveFilter() {
-		return enableCaseInsensitiveFilter;
-	}
-
-	@Override
-	public void setEnableCaseInsensitiveFilter(boolean enableCaseInsensitiveFilter) {
-		LOGGER.info("I AM SETTING CaseInsensitiveFilter : {0}", String.valueOf(enableCaseInsensitiveFilter));
-		this.enableCaseInsensitiveFilter = enableCaseInsensitiveFilter;
-
-	}
-
-	@Override
-	public boolean isFilteredResultsHandlerInValidationMode() {
-		return filteredResultsHandlerInValidationMode;
-	}
-
-	@Override
-	public void setFilteredResultsHandlerInValidationMode(boolean filteredResultsHandlerInValidationMode) {
-		LOGGER.info("I AM SETTING FilteredResultsHandlerInValidationMode : {0}",
-				String.valueOf(filteredResultsHandlerInValidationMode));
-		this.filteredResultsHandlerInValidationMode = filteredResultsHandlerInValidationMode;
-
-	}
-
-	@Override
-	public boolean isEnableFilteredResultsHandler() {
-		return enableFilteredResultsHandler;
-	}
-
-	@Override
-	public void setEnableFilteredResultsHandler(boolean enableFilteredResultsHandler) {
-		LOGGER.info("I AM SETTING FilteredResultsHandler: {0}", String.valueOf(enableFilteredResultsHandler));
-		this.enableFilteredResultsHandler = enableFilteredResultsHandler;
-
-	}
-
-	@Override
-	public boolean isEnableNormalizingResultsHandler() {
-		return enableNormalizingResultsHandler;
-	}
-
-	@Override
-	public void setEnableNormalizingResultsHandler(boolean enableNormalizingResultsHandler) {
-		LOGGER.info("I AM SETTING NormalizingResultsHandler: {0}", String.valueOf(enableNormalizingResultsHandler));
-		this.enableNormalizingResultsHandler = enableNormalizingResultsHandler;
-
-	}
-
 }

--- a/src/main/java/com/evolveum/polygon/connector/box/rest/FoldersHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/box/rest/FoldersHandler.java
@@ -474,15 +474,8 @@ public class FoldersHandler extends ObjectsProcessing {
 		} else if (query == null && objectClass.is(FOLDER_NAME)) {
 			handlerJson(handler, new Uid("0"));
 
-		} else if (configuration.isEnableFilteredResultsHandler()) {
-			handlerJson(handler, new Uid("0"));
-
 		} else {
-
-			StringBuilder sb = new StringBuilder();
-			sb.append("Method not allowed: ").append((query).getClass().getSimpleName().toString()).append(";")
-					.append("Please note that its recommended to enable filteredResultsHandler");
-			throw new ConnectorException(sb.toString());
+			handlerJson(handler, new Uid("0"));
 
 		}
 

--- a/src/main/java/com/evolveum/polygon/connector/box/rest/GroupHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/box/rest/GroupHandler.java
@@ -282,7 +282,7 @@ public class GroupHandler extends ObjectsProcessing {
 			HttpGet request = new HttpGet(uri);
 			handleGroups(request, handler, options, query);
 
-		} else if (configuration.isEnableFilteredResultsHandler()) {
+		} else {
 
 			uriBuilder.setPath(CRUD_GROUP);
 			try {
@@ -295,13 +295,6 @@ public class GroupHandler extends ObjectsProcessing {
 			}
 			HttpGet request = new HttpGet(uri);
 			handleGroups(request, handler, options, query);
-
-		} else {
-
-			StringBuilder sb = new StringBuilder();
-			sb.append("Method not allowed: ").append((query).getClass().getSimpleName().toString()).append(";")
-					.append("Please note that its recommended to enable filteredResultsHandler");
-			throw new ConnectorException(sb.toString());
 
 		}
 

--- a/src/main/java/com/evolveum/polygon/connector/box/rest/UserHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/box/rest/UserHandler.java
@@ -366,7 +366,7 @@ public class UserHandler extends ObjectsProcessing {
 			HttpGet request = new HttpGet(uri);
 			handleUsers(request, handler, query, options);
 
-		} else if (configuration.isEnableFilteredResultsHandler() == true) {
+		} else {
 
 			uriBuilder.setPath(CRUD);
 
@@ -380,13 +380,6 @@ public class UserHandler extends ObjectsProcessing {
 			}
 			HttpGet request = new HttpGet(uri);
 			handleUsers(request, handler, query, options);
-
-		} else {
-
-			StringBuilder sb = new StringBuilder();
-			sb.append("Method not allowed: ").append((query).getClass().getSimpleName().toString()).append(";")
-					.append("Please note that its recommended to enable filteredResultsHandler");
-			throw new ConnectorException(sb.toString());
 
 		}
 

--- a/src/test/java/com/evolveum/polygon/connector/box/test/AccountTests.java
+++ b/src/test/java/com/evolveum/polygon/connector/box/test/AccountTests.java
@@ -70,7 +70,6 @@ public class AccountTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 
 		connector.init(config);
 		connector.test();
@@ -85,7 +84,6 @@ public class AccountTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 
 		Schema schema = connector.schema();
@@ -162,7 +160,6 @@ public class AccountTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 
 		accountAttributes.clear();
@@ -453,7 +450,6 @@ public class AccountTests {
 		config.setRefreshToken(invalidRefreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(invalidAccessToken);
-		config.setEnableFilteredResultsHandler(false);
 
 		connector.init(config);
 		connector.test();
@@ -467,7 +463,6 @@ public class AccountTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.brx.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(false);
 
 		connector.init(config);
 
@@ -482,7 +477,6 @@ public class AccountTests {
 		configuration.setRefreshToken(refreshToken);
 		configuration.setUri("api.box.com");
 		configuration.setAccessToken(accessToken);
-		configuration.setEnableFilteredResultsHandler(false);
 
 		connector.init(configuration);
 
@@ -497,7 +491,6 @@ public class AccountTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 
 		if (accountUid != null) {
 			connector.delete(accountObject, accountUid, options);

--- a/src/test/java/com/evolveum/polygon/connector/box/test/FolderTests.java
+++ b/src/test/java/com/evolveum/polygon/connector/box/test/FolderTests.java
@@ -61,7 +61,6 @@ public class FolderTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 		connector.test();
 
@@ -75,7 +74,6 @@ public class FolderTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 
 		connector.init(config);
 
@@ -146,7 +144,6 @@ public class FolderTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 
 		connector.init(config);
 
@@ -196,7 +193,6 @@ public class FolderTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 
 		SearchResultsHandler handlerAccount = new SearchResultsHandler() {
@@ -231,7 +227,6 @@ public class FolderTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 
 		connector.create(folderObject, folderAttributes, null);

--- a/src/test/java/com/evolveum/polygon/connector/box/test/GroupTests.java
+++ b/src/test/java/com/evolveum/polygon/connector/box/test/GroupTests.java
@@ -60,7 +60,6 @@ public class GroupTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 		connector.test();
 
@@ -74,7 +73,6 @@ public class GroupTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 
 		Schema schema = connector.schema();
@@ -149,7 +147,6 @@ public class GroupTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 
 		connector.init(config);
 
@@ -243,7 +240,6 @@ public class GroupTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 
 		SearchResultsHandler handlerAccount = new SearchResultsHandler() {
@@ -278,7 +274,6 @@ public class GroupTests {
 		config.setRefreshToken(refreshToken);
 		config.setUri("api.box.com");
 		config.setAccessToken(accessToken);
-		config.setEnableFilteredResultsHandler(true);
 		connector.init(config);
 
 		connector.create(groupObject, groupAttributes, null);


### PR DESCRIPTION
It could not be built for the following reason.

* Connector Framework 1.4.3.0-SNAPSHOT does not exist in the maven repository.
* Connector Framework does not have ConfigurationForResultsHandler interface now.

To resolve build errors, I changed the version and remove the implementation of the ConfigurationForResultsHandler interface.